### PR TITLE
Jhouck fix issue 3160

### DIFF
--- a/mne/event.py
+++ b/mne/event.py
@@ -777,10 +777,10 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     if n_events == 0:
         raise ValueError('No events produced, check the values of start, stop, and duration') 
     events = np.c_[ts, np.zeros(n_events, dtype=int),
-                   id * np.ones(n_events, dtype=int)]    
-    return events       
-    
-    
+                   id * np.ones(n_events, dtype=int)]
+    return events
+
+
 def concatenate_events(events, first_samps, last_samps):
     """Concatenate event lists in a manner compatible with
     concatenate_raws

--- a/mne/event.py
+++ b/mne/event.py
@@ -746,9 +746,9 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     duration: float
         The duration to separate events by.
     first_samp: bool
-        If True (default), times will have raw.first_samp added to them,
-        as in :func:`mne.find_events`. This behavior is not desirable if 
-        the returned events will be combined with event times that already 
+        If True (default), times will have raw.first_samp added to them, as 
+        in :func:`mne.find_events`.  This behavior is not desirable if the 
+        returned events will be combined with event times that already 
         have ``raw.first_samp`` added to them, e.g. event times that come 
         from :func:`mne.find_events`.
 
@@ -758,13 +758,15 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
         The new events.
     """
     start = raw.time_as_index(start)
-    if first_samp:
-        start = start[0] + raw.first_samp
     if stop is not None:
         stop = raw.time_as_index(stop)
-        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])
     else:
-        stop = raw.last_samp + 1
+        stop = raw.last_samp + 1    
+    if first_samp:
+        start = start[0] + raw.first_samp
+        stop = min([stop[0] + raw.first_samp, raw.last_samp + 1])  
+    else:
+        stop = min([stop[0], len(raw.times)])
     if not isinstance(id, int):
         raise ValueError('id must be an integer')
     # Make sure we don't go out the end of the file:
@@ -772,11 +774,13 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     # This should be inclusive due to how we generally use start and stop...
     ts = np.arange(start, stop + 1, raw.info['sfreq'] * duration).astype(int)
     n_events = len(ts)
+    if n_events == 0:
+        raise ValueError('No events produced, check the values of start, stop, and duration') 
     events = np.c_[ts, np.zeros(n_events, dtype=int),
-                   id * np.ones(n_events, dtype=int)]
-    return events
-
-
+                   id * np.ones(n_events, dtype=int)]    
+    return events       
+    
+    
 def concatenate_events(events, first_samps, last_samps):
     """Concatenate event lists in a manner compatible with
     concatenate_raws

--- a/mne/event.py
+++ b/mne/event.py
@@ -746,8 +746,8 @@ def make_fixed_length_events(raw, id, start=0, stop=None, duration=1., first_sam
     duration: float
         The duration to separate events by.
     first_samp: bool
-        If True (default), times will have raw.first_samp added to them, as 
-        in :func:`mne.find_events`.  This behavior is not desirable if the 
+        If True (default), times will have raw.first_samp added to them, as
+        in :func:`mne.find_events`. This behavior is not desirable if the 
         returned events will be combined with event times that already 
         have ``raw.first_samp`` added to them, e.g. event times that come 
         from :func:`mne.find_events`.


### PR DESCRIPTION
Change to use len(raw.times) rather than raw.last_samp - raw.first_samp, and add error message when no events would be produced.
